### PR TITLE
Smtp/#210 disable login

### DIFF
--- a/notifiers/providers/email.py
+++ b/notifiers/providers/email.py
@@ -72,6 +72,7 @@ class SMTP(Provider):
                 "type": "boolean",
                 "title": "should the email be parse as an HTML file",
             },
+            "login": {"type": "boolean", "title": "Trigger login to server"}
         },
         "dependencies": {
             "username": ["password"],
@@ -96,6 +97,7 @@ class SMTP(Provider):
             "tls": False,
             "ssl": False,
             "html": False,
+            "login": True,
         }
 
     def _prepare_data(self, data: dict) -> dict:
@@ -134,7 +136,7 @@ class SMTP(Provider):
             self.smtp_server.ehlo()
             self.smtp_server.starttls()
 
-        if data.get("username"):
+        if data["login"] and data.get("username"):
             self.smtp_server.login(data["username"], data["password"])
 
     @staticmethod

--- a/source/changelog.rst
+++ b/source/changelog.rst
@@ -3,8 +3,8 @@
 Changelog
 =========
 
-Unreleased
-----------
+1.2.0 (Unreleased)
+------------------
 
 - Added ability to cancel login to SMTP/GMAIL if credentials are used (`#210 <https://github.com/notifiers/notifiers/issues/210>`_, `#266 <https://github.com/notifiers/notifiers/pull/266>`_)
 

--- a/source/changelog.rst
+++ b/source/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 Unreleased
 ----------
 
-- Added ability to cancel login to SMTP/GMAIL if credentials are used (`#210 <https://github.com/notifiers/notifiers/issues/210>`_)
+- Added ability to cancel login to SMTP/GMAIL if credentials are used (`#210 <https://github.com/notifiers/notifiers/issues/210>`_, `#266 <https://github.com/notifiers/notifiers/pull/266>`_)
 
 1.0.4
 ------

--- a/source/changelog.rst
+++ b/source/changelog.rst
@@ -3,10 +3,16 @@
 Changelog
 =========
 
-Dev (Unreleased)
-----------------
+Unreleased
+----------
+
+- Added ability to cancel login to SMTP/GMAIL if credentials are used (`#210 <https://github.com/notifiers/notifiers/issues/210>`_)
+
+1.0.4
+------
 
 - Added `black <https://github.com/ambv/black>`_ and `pre-commit <https://pre-commit.com/>`_
+- Updated deps
 
 1.0.0
 -----

--- a/source/providers/email.rst
+++ b/source/providers/email.rst
@@ -97,6 +97,9 @@ Full schema:
       username:
         title: username if relevant
         type: string
+      login:
+        title: Trigger login to server
+        type: boolean
     required:
     - message
     - to


### PR DESCRIPTION
Added new `login` keyword to SMTP/Gmail, with a default of `True`