### PR TITLE
Add homebrew installation method instruction

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -31,6 +31,10 @@ Via pip:
 ```
 $ pip install notifiers
 ```
+Via homebrew:
+```
+$ brew install notifiers
+```
 Or Dockerhub:
 ```
 $ docker pull liiight/notifiers


### PR DESCRIPTION
Closes #78 

I just used the GitHub's release tarball first instead of the PyPI's tarball to make this PR to the homebrew-core repo: https://github.com/Homebrew/homebrew-core/pull/44926 

But for the next version, please see my comment in #308 so that we can use the PyPI's tarball instead the one in GitHub.

PS: Please wait for the PR to the `homebrew-core` to be merged.